### PR TITLE
Fix x86 release build in c_api.cc

### DIFF
--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -735,7 +735,7 @@ XGB_DLL int XGBoosterPredictFromCSR(BoosterHandle handle, char const *indptr,
   CHECK_HANDLE();
   std::shared_ptr<xgboost::data::CSRArrayAdapter> x{
       new xgboost::data::CSRArrayAdapter{
-          StringView{indptr}, StringView{indices}, StringView{data}, cols}};
+          StringView{indptr}, StringView{indices}, StringView{data}, (size_t)cols}};
   std::shared_ptr<DMatrix> p_m {nullptr};
   if (m) {
     p_m = *static_cast<std::shared_ptr<DMatrix> *>(m);


### PR DESCRIPTION
Following error was fixed in x86 release build
Error C2398: Element '4': conversion from 'xgboost::bst_ulong' to 'size_t' requires a narrowing conversion, xgboost\src\c_api\c_api.cc 738