### PR TITLE
Fix x86 release build in gbtree.cc

### DIFF
--- a/src/gbm/gbtree.cc
+++ b/src/gbm/gbtree.cc
@@ -231,7 +231,7 @@ void GBTree::DoBoost(DMatrix* p_fmat,
                     : in_gpair->DeviceIdx();
   auto out = MatrixView<float>(
       &predt->predictions,
-      {p_fmat->Info().num_row_, static_cast<size_t>(ngroup)}, device);
+      {(size_t)(p_fmat->Info().num_row_), static_cast<size_t>(ngroup)}, device);
   CHECK_NE(ngroup, 0);
   if (ngroup == 1) {
     std::vector<std::unique_ptr<RegTree>> ret;


### PR DESCRIPTION
Following error was fixed in x86 release build
Error_C2397: conversion from 'uint64_t' to '_Ty' requires a narrowing conversion, xgboost\src\gbm\gbtree.cc 234